### PR TITLE
#8 Add null-check with corresponding test

### DIFF
--- a/src/main/java/nl/ricoapon/fileanalyser/internal/StorageInstanceContainer.java
+++ b/src/main/java/nl/ricoapon/fileanalyser/internal/StorageInstanceContainer.java
@@ -30,6 +30,7 @@ public class StorageInstanceContainer {
      * @throws FileAnalyserConfigurationException When more than one instance is supplied for a single class.
      */
     public StorageInstanceContainer(List<Object> storageInstancesList) {
+        Objects.requireNonNull(storageInstancesList);
         storageInstances = new HashMap<>();
         for (Object storageInstance : storageInstancesList) {
             Class<?> storageInstanceClass = storageInstance.getClass();

--- a/src/test/java/nl/ricoapon/fileanalyser/internal/StorageInstanceContainerTest.java
+++ b/src/test/java/nl/ricoapon/fileanalyser/internal/StorageInstanceContainerTest.java
@@ -119,4 +119,10 @@ class StorageInstanceContainerTest {
         assertThat(result1, equalTo(instanceMap));
         assertThat(result2, equalTo(instanceMap));
     }
+
+    @Test
+    void constructorThrowsNpeWithNullInput() {
+        assertThrows(NullPointerException.class, () -> new StorageInstanceContainer((Map<Class<?>, Object>) null));
+        assertThrows(NullPointerException.class, () -> new StorageInstanceContainer((List<Object>) null));
+    }
 }

--- a/src/test/java/nl/ricoapon/fileanalyser/internal/StorageInstanceContainerTest.java
+++ b/src/test/java/nl/ricoapon/fileanalyser/internal/StorageInstanceContainerTest.java
@@ -10,7 +10,6 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.in;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")


### PR DESCRIPTION
The constructor with map parameter already had a null-check, but the
constructor wit list parameter didn't. Also no test was there to make
sure that NPE was thrown. This has been fixed.